### PR TITLE
Enforce more secure TLS version in newer API

### DIFF
--- a/tutorials/mq-realtime-fabric-dashboard/deployEdgeAndCloudResources.bicep
+++ b/tutorials/mq-realtime-fabric-dashboard/deployEdgeAndCloudResources.bicep
@@ -352,7 +352,7 @@ resource kcTopicmap 'Microsoft.IoTOperationsMQ/mq/kafkaConnector/topicMap@2023-1
 param eventHubSku string = 'Standard'
 
 
-resource eventHubNamespace 'Microsoft.EventHub/namespaces@2021-11-01' = {
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: 'ehns-${uniqueString(resourceGroup().id)}'
   location: location
   sku: {
@@ -363,6 +363,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2021-11-01' = {
   properties: {
     isAutoInflateEnabled: false
     maximumThroughputUnits: 0
+    minimumTlsVersion: '1.2'
   }
 }
 


### PR DESCRIPTION
This templates uses the default Event Hub TLS version of 1.0, which has lots of security holes. Event Hub can be forced to use TLS1.2 and above.

TLS1.2 has been standard for very long time (Windows 2008R2).