### PR TITLE
update quickstart opc plc deployment to use standalone self-signed ce…

### DIFF
--- a/samples/quickstarts/opc-plc-deployment.yaml
+++ b/samples/quickstarts/opc-plc-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opc-plc-deployment
+  name: opc-plc-000000
   namespace: azure-iot-operations
   labels:
     app.kubernetes.io/component: opcplc-000000
@@ -22,38 +22,42 @@ spec:
           - "--ph=opcplc-000000"
           - "--cdn=opcplc-000000"
           - "--ut"
-          - "--trustowncert" # Can we remove?
           - "--sn=25"
           - "--sr=10"
           - "--fn=2000"
-          - "--veryfastrate=1000"          
+          - "--veryfastrate=1000"
           - "--gn=5"
           - "--pn=50000"
           - "--maxsessioncount=100"
           - "--maxsubscriptioncount=100"
-          - "--maxqueuedrequestcount=2000"          
+          - "--maxqueuedrequestcount=2000"
           - "--ses"
           - "--alm"
           - "--at=FlatDirectory"
-          - "--drurs"        
+          - "--drurs"
           - "--ll-debug"
         ports:
         - containerPort: 50000
         volumeMounts:
-          - name: opc-plc-tls
+          - name: opc-plc-default-application-cert
             mountPath: /app/pki/own
-          - name: opc-plc-tls
-            mountPath: /app/pki/trusted # Trust own cert
+          - name: opc-plc-trust-list
+            mountPath: /app/pki/trusted
       volumes:
-        - name: opc-plc-tls
+        - name: opc-plc-default-application-cert
           secret:
-            secretName: opc-plc-tls
+            secretName: opc-plc-default-application-cert
+        - name: opc-plc-trust-list
+          secret:
+            secretName: opc-plc-trust-list
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: opcplc-000000
   namespace: azure-iot-operations
+  labels:
+    app.kubernetes.io/component: opcplc-000000
 spec:
   type: ClusterIP
   selector:
@@ -64,16 +68,28 @@ spec:
       targetPort: 50000
 ---
 apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: opc-plc-self-signed-issuer
+  namespace: azure-iot-operations
+  labels:
+    app.kubernetes.io/component: opcplc-000000
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: opc-plc-certificate
+  name: opc-plc-default-application-cert
   namespace: azure-iot-operations
+  labels:
+    app.kubernetes.io/component: opcplc-000000
 spec:
-  secretName: opc-plc-tls
+  secretName: opc-plc-default-application-cert
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   issuerRef:
-    name: aio-opc-opcuabroker-default-root-ca-issuer
+    name: opc-plc-self-signed-issuer
     kind: Issuer
   commonName: OpcPlc
   dnsNames:
@@ -93,3 +109,13 @@ spec:
     size: 2048
   encodeUsagesInRequest: true
   isCA: false
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: opc-plc-trust-list
+  namespace: azure-iot-operations
+  labels:
+    app.kubernetes.io/component: opcplc-000000
+data:
+  # empty


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

* opc plc can be deployed completely independent from the aio. It only requires that `azure-iot-operations` namespace exists.
* the user will have to manually establish mutual trust between opc ua connector and the opc plc as in the example below:

PowerShell
```PowerShell
# extract the opc ua connector application instance cert and add it to the opc plc's trust list
kubectl -n azure-iot-operations get secret aio-opc-opcuabroker-default-application-cert -o jsonpath='{.data.tls\.crt}' | %{ [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($_)) } > opcuabroker.crt
$data = kubectl create secret generic temp --from-file=opcuabroker.crt=./opcuabroker.crt --dry-run=client -o jsonpath='{.data}'
kubectl patch secret opc-plc-trust-list -n azure-iot-operations -p "{`"data`": $data}"
rm ./opcuabroker.crt

# extract the opc plc application instance cert and add it to the opc ua connector's trust list
kubectl -n azure-iot-operations get secret opc-plc-default-application-cert -o jsonpath='{.data.tls\.crt}' | %{ [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($_)) } > opcplc.crt
$data = kubectl create secret generic temp --from-file=opcplc-000000.crt=./opcplc.crt --dry-run=client -o jsonpath='{.data}'
kubectl patch secret aio-opc-ua-broker-trust-list -n azure-iot-operations -p "{`"data`": $data}"
rm ./opcplc.crt
```
Bash
```Bash
# extract the opc ua connector application instance cert and add it to the opc plc's trust list
kubectl -n azure-iot-operations get secret aio-opc-opcuabroker-default-application-cert -o jsonpath='{.data.tls\.crt}' | base64 -d > opcuabroker.crt
data=$(kubectl create secret generic temp --from-file=opcuabroker.crt=./opcuabroker.crt --dry-run=client -o jsonpath='{.data}')
kubectl patch secret opc-plc-trust-list -n azure-iot-operations -p "{\"data\": $data}"
rm ./opcuabroker.crt

# extract the opc plc application instance cert and add it to the opc ua connector's trust list
kubectl -n azure-iot-operations get secret opc-plc-default-application-cert -o jsonpath='{.data.tls\.crt}' | base64 -d > opcplc.crt
data=$(kubectl create secret generic temp --from-file=opcplc-000000.crt=./opcplc.crt --dry-run=client -o jsonpath='{.data}')
kubectl patch secret aio-opc-ua-broker-trust-list -n azure-iot-operations -p "{\"data\": $data}"
rm ./opcplc.crt
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->