### PR TITLE
Trim to make cluster name shorter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,9 +33,7 @@
   "containerEnv": {
     // This env var is important to allow k3s to support shared mounts, required for CSI driver
     // Temporary fix until made default https://github.com/k3d-io/k3d/pull/1268#issuecomment-1745466499
-    "K3D_FIX_MOUNTS": "1",
-    // Set the cluster name to the name of the cluster created by the GitHub Codespace
-    "CLUSTER_NAME": "${localEnv:CODESPACE_NAME}"
+    "K3D_FIX_MOUNTS": "1"
   },
   "onCreateCommand": "bash .devcontainer/onCreateCommand.sh",
   "postStartCommand": "bash .devcontainer/postStartCommand.sh"

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,4 +1,5 @@
 echo 'export CODESPACES="FALSE"' >> ~/.bashrc
+echo 'export CLUSTER_NAME=${CODESPACE_NAME%-*}' >> ~/.bashrc
 source ~/.bashrc
 
 echo -e "Environment: \nSUBSCRIPTION_ID: $SUBSCRIPTION_ID \nRESOURCE_GROUP: $RESOURCE_GROUP \nLOCATION: $LOCATION \nCLUSTER_NAME: $CLUSTER_NAME"


### PR DESCRIPTION
Instead of initializing the `CLUSTER_NAME` environment variable in the `.devcontainer/devcontainer.json` file with the value of `${localEnv:CODESPACE_NAME}`, this pull request uses the `.devcontainer/postStartCommand.sh` script to set the `CLUSTER_NAME` environment variable to the value of `${CODESPACE_NAME%-*}` via `~/.bashrc`. This change shortens the cluster name by removing the suffix after and including the last hyphen in the `CODESPACE_NAME` environment variable.

For example, my `CODESPACE_NAME` is `friendly-couscous-p74x5x57qp2xgg`, and the `CLUSTER_NAME` will be set to `friendly-couscous` after this change. 

The change also makes the cluster name match the codespace name as displayed by VS Code

![image](https://github.com/user-attachments/assets/8640b7ea-6d19-4116-8ea3-c11c332b036e)

This makes the cluster name significantly shorter and probably means that we don't need to trim the Event Hub names any more.