### PR TITLE
Fix Codespaces prebuild k3d startup

### DIFF
--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -6,13 +6,11 @@ set -o pipefail
 
 echo "Starting On Create Command"
 
-# Copy the custom first run notice over
+# Copy the custom first run notice over.
 sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
 
-# Create k3d cluster and forwarded ports
-k3d cluster delete
-k3d cluster create \
--p '1883:1883@loadbalancer' \
--p '8883:8883@loadbalancer'
+# Keep this script prebuild-safe. GitHub Codespaces prebuilds run onCreateCommand
+# before snapshotting the filesystem, so don't start Docker/k3d workloads here.
+# The k3d cluster is created lazily in postStartCommand.sh for real codespaces.
 
 echo "Ending On Create Command"

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,5 +1,39 @@
-echo 'export CODESPACES="FALSE"' >> ~/.bashrc
-echo 'export CLUSTER_NAME=${CODESPACE_NAME%-*}-codespace' >> ~/.bashrc
-source ~/.bashrc
+#!/usr/bin/env bash
 
-echo -e "Environment: \nSUBSCRIPTION_ID: $SUBSCRIPTION_ID \nRESOURCE_GROUP: $RESOURCE_GROUP \nLOCATION: $LOCATION \nCLUSTER_NAME: $CLUSTER_NAME"
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BASHRC="${HOME}/.bashrc"
+touch "${BASHRC}"
+
+# Keep the helper environment exports idempotent across codespace restarts.
+grep -qxF 'export CODESPACES="FALSE"' "${BASHRC}" || echo 'export CODESPACES="FALSE"' >> "${BASHRC}"
+grep -qxF 'export CLUSTER_NAME=${CODESPACE_NAME%-*}-codespace' "${BASHRC}" || echo 'export CLUSTER_NAME=${CODESPACE_NAME%-*}-codespace' >> "${BASHRC}"
+
+export CODESPACES="FALSE"
+if [[ -n "${CODESPACE_NAME:-}" ]]; then
+  export CLUSTER_NAME="${CODESPACE_NAME%-*}-codespace"
+else
+  export CLUSTER_NAME="${CLUSTER_NAME:-k3s-default}"
+fi
+
+printf 'Environment:\nSUBSCRIPTION_ID: %s\nRESOURCE_GROUP: %s\nLOCATION: %s\nCLUSTER_NAME: %s\n' \
+  "${SUBSCRIPTION_ID:-}" \
+  "${RESOURCE_GROUP:-}" \
+  "${LOCATION:-}" \
+  "${CLUSTER_NAME}"
+
+if [[ "${SKIP_K3D_CLUSTER_CREATE:-}" == "1" ]]; then
+  echo "Skipping k3d cluster creation because SKIP_K3D_CLUSTER_CREATE=1."
+  exit 0
+fi
+
+if k3d cluster list -o json 2>/dev/null | grep -q '"name"[[:space:]]*:[[:space:]]*"k3s-default"'; then
+  echo "k3d cluster 'k3s-default' already exists."
+else
+  echo "Creating k3d cluster 'k3s-default'."
+  k3d cluster create \
+    -p '1883:1883@loadbalancer' \
+    -p '8883:8883@loadbalancer'
+fi

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -9,7 +9,14 @@ touch "${BASHRC}"
 
 # Keep the helper environment exports idempotent across codespace restarts.
 grep -qxF 'export CODESPACES="FALSE"' "${BASHRC}" || echo 'export CODESPACES="FALSE"' >> "${BASHRC}"
-grep -qxF 'export CLUSTER_NAME=${CODESPACE_NAME%-*}-codespace' "${BASHRC}" || echo 'export CLUSTER_NAME=${CODESPACE_NAME%-*}-codespace' >> "${BASHRC}"
+if ! grep -qxF '# devcontainer-cluster-name' "${BASHRC}"; then
+  cat >> "${BASHRC}" <<'EOF'
+# devcontainer-cluster-name
+if [[ -n "${CODESPACE_NAME:-}" ]]; then
+  export CLUSTER_NAME="${CODESPACE_NAME%-*}-codespace"
+fi
+EOF
+fi
 
 export CODESPACES="FALSE"
 if [[ -n "${CODESPACE_NAME:-}" ]]; then


### PR DESCRIPTION
## Summary

- keep `onCreateCommand` prebuild-safe by moving k3d cluster creation out of it
- create the k3d cluster lazily from `postStartCommand` for real codespaces
- make the `postStartCommand` environment setup idempotent across restarts

## Why

Recent Codespaces prebuilds for `.devcontainer/devcontainer.json` have been intermittently failing after the devcontainer setup completes, during GitHub's template/snapshot phase:

```text
Jobs failed, exiting the agent. Job 'ShrinkExt4' did not succeed.
```

The prebuild logs show `onCreateCommand` successfully creating a k3d cluster before GitHub tries to snapshot/shrink the filesystem. Codespaces prebuilds run `onCreateCommand`, so leaving nested Docker/k3d state around during the snapshot step is risky and appears to be the source of the flake.

GitHub docs confirm prebuilds run setup through `onCreateCommand` before taking the snapshot:
https://docs.github.com/en/codespaces/prebuilding-your-codespaces/about-github-codespaces-prebuilds#the-prebuild-process

## Validation

- `bash -n .devcontainer/onCreateCommand.sh`
- `bash -n .devcontainer/postStartCommand.sh`
- Ran `postStartCommand.sh` twice with `SKIP_K3D_CLUSTER_CREATE=1` and a temp home to verify `.bashrc` updates are idempotent.