### PR TITLE
Fix WASM graph module paths for GHCR artifacts

### DIFF
--- a/samples/wasm/graph-complex.yaml
+++ b/samples/wasm/graph-complex.yaml
@@ -34,43 +34,43 @@ operations:
 
   - operationType: delay
     name: module-window/delay
-    module: window:1.0.0
+    module: "azure-samples/explore-iot-operations/window:1.0.0"
   - operationType: "map"
     name: "module-format/map"
-    module: "format:1.0.0"
+    module: "azure-samples/explore-iot-operations/format:1.0.0"
   - operationType: map
     name: module-snapshot/map
-    module: snapshot:1.0.0
+    module: "azure-samples/explore-iot-operations/snapshot:1.0.0"
   - operationType: branch
     name: module-snapshot/branch
-    module: snapshot:1.0.0
+    module: "azure-samples/explore-iot-operations/snapshot:1.0.0"
   - operationType: accumulate
     name: module-snapshot/accumulate
-    module: snapshot:1.0.0
+    module: "azure-samples/explore-iot-operations/snapshot:1.0.0"
   - operationType: map
     name: module-temperature/map
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: branch
     name: module-temperature/branch
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: filter
     name: module-temperature/filter
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: accumulate
     name: module-temperature/accumulate
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: accumulate
     name: module-humidity/accumulate
-    module: humidity:1.0.0
+    module: "azure-samples/explore-iot-operations/humidity:1.0.0"
   - operationType: concatenate
     name: concatenate1
     module:
   - operationType: accumulate
     name: module-collection/accumulate
-    module: collection:1.0.0
+    module: "azure-samples/explore-iot-operations/collection:1.0.0"
   - operationType: map
     name: module-enrichment/map
-    module: enrichment:1.0.0
+    module: "azure-samples/explore-iot-operations/enrichment:1.0.0"
 
   - operationType: "sink"
     name: "sink"

--- a/samples/wasm/graph-opc-ua.yaml
+++ b/samples/wasm/graph-opc-ua.yaml
@@ -27,7 +27,7 @@ operations:
     name: "source"
   - operationType: "map"
     name: "module-opc/map"
-    module: "opc-ua:1.0.0"
+    module: "azure-samples/explore-iot-operations/opc-ua:1.0.0"
   - operationType: "sink"
     name: "sink"
 

--- a/samples/wasm/graph-otel-transform.yaml
+++ b/samples/wasm/graph-otel-transform.yaml
@@ -36,7 +36,7 @@ operations:
     name: "source"
   - operationType: "map"
     name: "module-otel-transform/map"
-    module: "otel-transform:1.0.0"
+    module: "azure-samples/explore-iot-operations/otel-transform:1.0.0"
   - operationType: "sink"
     name: "sink"
 

--- a/samples/wasm/graph-otel.yaml
+++ b/samples/wasm/graph-otel.yaml
@@ -41,10 +41,10 @@ operations:
     name: "source"
   - operationType: "map"
     name: "module-otel-transform/map"
-    module: "otel-transform:1.0.0"
+    module: "azure-samples/explore-iot-operations/otel-transform:1.0.0"
   - operationType: "map"
     name: "module-otel-enrich/map"
-    module: "otel-enrich:1.0.0"
+    module: "azure-samples/explore-iot-operations/otel-enrich:1.0.0"
   - operationType: "sink"
     name: "sink"
 

--- a/samples/wasm/graph-simple.yaml
+++ b/samples/wasm/graph-simple.yaml
@@ -21,7 +21,7 @@ operations:
 
   - operationType: "map"
     name: "module-temperature/map"
-    module: "temperature:1.0.0"
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
 
   - operationType: "sink"
     name: "sink"

--- a/samples/wasm/graph.dataflow.yaml
+++ b/samples/wasm/graph.dataflow.yaml
@@ -38,43 +38,43 @@ operations:
 
   - operationType: delay
     name: module-window/delay
-    module: window:1.0.0
+    module: "azure-samples/explore-iot-operations/window:1.0.0"
   - operationType: "map"
     name: "module-format/map"
-    module: "format:1.0.0"
+    module: "azure-samples/explore-iot-operations/format:1.0.0"
   - operationType: map
     name: module-snapshot/map
-    module: snapshot:1.0.0
+    module: "azure-samples/explore-iot-operations/snapshot:1.0.0"
   - operationType: branch
     name: module-snapshot/branch
-    module: snapshot:1.0.0
+    module: "azure-samples/explore-iot-operations/snapshot:1.0.0"
   - operationType: accumulate
     name: module-snapshot/accumulate
-    module: snapshot:1.0.0
+    module: "azure-samples/explore-iot-operations/snapshot:1.0.0"
   - operationType: map
     name: module-temperature/map
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: branch
     name: module-temperature/branch
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: filter
     name: module-temperature/filter
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: accumulate
     name: module-temperature/accumulate
-    module: temperature:1.0.0
+    module: "azure-samples/explore-iot-operations/temperature:1.0.0"
   - operationType: accumulate
     name: module-humidity/accumulate
-    module: humidity:1.0.0
+    module: "azure-samples/explore-iot-operations/humidity:1.0.0"
   - operationType: concatenate
     name: concatenate1
     module:
   - operationType: accumulate
     name: module-collection/accumulate
-    module: collection:1.0.0
+    module: "azure-samples/explore-iot-operations/collection:1.0.0"
   - operationType: map
     name: module-enrichment/map
-    module: enrichment:1.0.0
+    module: "azure-samples/explore-iot-operations/enrichment:1.0.0"
 
   - operationType: "sink"
     name: "sink"


### PR DESCRIPTION
## Summary

Update WASM graph definition module references so the GHCR-published graph artifacts resolve their dependent modules correctly with the current registry endpoint behavior.

The runtime now treats the RegistryEndpoint `host` as the registry hostname only (for example, `ghcr.io`). For graph artifacts under `ghcr.io/azure-samples/explore-iot-operations`, module references in the graph need to include the repository path, for example:

```yaml
module: "azure-samples/explore-iot-operations/temperature:1.0.0"
```

instead of:

```yaml
module: "temperature:1.0.0"
```

## Changes

- Updated published sample graph YAMLs under `samples/wasm/*.yaml` to include `azure-samples/explore-iot-operations/` in module references.
- Left non-published README snippets alone, since flat registry layouts can still use short module references.

## Validation

- Parsed all changed `samples/wasm/*.yaml` files with PyYAML.
- Verified the workaround end-to-end on an AIO k3s cluster using a temporary public GHCR package:
  - RegistryEndpoint `host: ghcr.io`, anonymous auth.
  - Graph artifact included repo-qualified module ref.
  - Graph and module both downloaded.
  - Dataflow worker reached Ready.
  - DataflowGraph became Available.

Related ADO bug: https://dev.azure.com/msazure/One/_workitems/edit/38222850
