### PR TITLE
Release/august

### DIFF
--- a/quickstart/config/advanced_config.template
+++ b/quickstart/config/advanced_config.template
@@ -34,9 +34,7 @@
   },
   "modules": {
     "edgemqttsim": false,
-    "hello-flask": false,
-    "sputnik": false,
-    "wasm-quality-filter-python": false
+    "demohistorian": false
   },
   "comments": {
     "config_type": "Advanced mode: manual control with skip flags for kubeconfig, container registry, and certificates; Quickstart mode: fully automated setup with Arc and IoT Operations.",
@@ -68,9 +66,7 @@
     },
     "modules": {
       "edgemqttsim": "Factory telemetry simulator. Enable for testing MQTT connectivity and data pipelines.",
-      "hello-flask": "Simple Flask web app. Enable for basic cluster validation.",
-      "sputnik": "Advanced application. Enable for comprehensive testing.",
-      "wasm-quality-filter-python": "WebAssembly edge filter. Enable for production edge processing."
+      "demohistorian": "MQTT historian with PostgreSQL storage and a query API."
     },
     "advanced_workflow": [
       "1. Installer sets up K3s cluster (kubeconfig optional based on skip_kubeconfig_setup)",

--- a/quickstart/external_configuration/Deploy-EdgeModules.ps1
+++ b/quickstart/external_configuration/Deploy-EdgeModules.ps1
@@ -3,7 +3,7 @@
     Deploy edge modules to Azure IoT Operations cluster via kubectl through Azure Arc proxy
 
 .DESCRIPTION
-    This script deploys edge modules (edgemqttsim, hello-flask, sputnik, demohistorian)
+    This script deploys edge modules (edgemqttsim and demohistorian)
     to the Kubernetes cluster using kubectl through Azure Arc proxy. Runs remotely from Windows
     to edge device on different network.
     
@@ -35,7 +35,7 @@
     .\Deploy-EdgeModules.ps1 -ModuleName edgemqttsim
 
 .EXAMPLE
-    .\Deploy-EdgeModules.ps1 -ModuleName hello-flask -Force
+    .\Deploy-EdgeModules.ps1 -ModuleName demohistorian -Force
 
 .EXAMPLE
     .\Deploy-EdgeModules.ps1 -SkipBuild
@@ -51,7 +51,7 @@ param(
     [string]$ConfigPath,
     
     [Parameter(Mandatory=$false)]
-    [ValidateSet("edgemqttsim", "hello-flask", "sputnik", "demohistorian")]
+    [ValidateSet("edgemqttsim", "demohistorian")]
     [string]$ModuleName,
     
     [Parameter(Mandatory=$false)]
@@ -191,9 +191,7 @@ function Load-Configuration {
         Write-WarnLog "No modules section found in configuration, creating default"
         $modulesConfig = [PSCustomObject]@{
             edgemqttsim = $false
-            "hello-flask" = $false
-            sputnik = $false
-            "wasm-quality-filter-python" = $false
+            demohistorian = $false
         }
         $config | Add-Member -NotePropertyName "modules" -NotePropertyValue $modulesConfig -Force
     }
@@ -834,6 +832,75 @@ function Ensure-ServiceAccount {
     }
 }
 
+function Ensure-MqttBrokerTrustBundle {
+    param(
+        [string]$SourceNamespace = "azure-iot-operations",
+        [string]$TargetNamespace = "default",
+        [string]$ConfigMapName = "azure-iot-operations-aio-ca-trust-bundle"
+    )
+
+    Write-InfoLog "Refreshing MQTT broker CA trust bundle for namespace '$TargetNamespace'..."
+
+    $previousErrorPref = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+
+    try {
+        $sourceJson = kubectl get configmap $ConfigMapName -n $SourceNamespace -o json 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-ErrorLog "MQTT broker CA unavailable: ConfigMap $SourceNamespace/$ConfigMapName could not be read; deployment stopped."
+            Write-ErrorLog "kubectl output: $sourceJson"
+            return $false
+        }
+
+        try {
+            $sourceJsonText = $sourceJson -join [Environment]::NewLine
+            $sourceConfigMap = $sourceJsonText | ConvertFrom-Json -ErrorAction Stop
+            $caCertificate = $sourceConfigMap.data.'ca.crt'
+        }
+        catch {
+            Write-ErrorLog "MQTT broker CA unavailable: ConfigMap $SourceNamespace/$ConfigMapName is invalid; deployment stopped."
+            return $false
+        }
+
+        if ([string]::IsNullOrWhiteSpace($caCertificate)) {
+            Write-ErrorLog "MQTT broker CA unavailable: ConfigMap $SourceNamespace/$ConfigMapName does not contain ca.crt; deployment stopped."
+            return $false
+        }
+
+        $tempCaPath = Join-Path $env:TEMP "aio-mqtt-ca-$([guid]::NewGuid().ToString('N')).crt"
+        try {
+            [System.IO.File]::WriteAllText($tempCaPath, $caCertificate)
+
+            $configMapYaml = kubectl create configmap $ConfigMapName `
+                --namespace=$TargetNamespace `
+                --from-file="ca.crt=$tempCaPath" `
+                --dry-run=client -o yaml 2>&1
+
+            if ($LASTEXITCODE -ne 0) {
+                Write-ErrorLog "Failed to prepare MQTT broker CA ConfigMap in namespace '$TargetNamespace'."
+                Write-ErrorLog "kubectl output: $configMapYaml"
+                return $false
+            }
+
+            $applyResult = $configMapYaml | kubectl apply -f - 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-ErrorLog "Failed to apply MQTT broker CA ConfigMap in namespace '$TargetNamespace'."
+                Write-ErrorLog "kubectl output: $applyResult"
+                return $false
+            }
+        }
+        finally {
+            Remove-Item $tempCaPath -Force -ErrorAction SilentlyContinue
+        }
+
+        Write-Success "MQTT broker CA trust bundle refreshed: $SourceNamespace/$ConfigMapName -> $TargetNamespace/$ConfigMapName"
+        return $true
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorPref
+    }
+}
+
 function Ensure-AcrPullSecret {
     param(
         [string]$Registry,
@@ -852,19 +919,21 @@ function Ensure-AcrPullSecret {
     # Extract ACR name (everything before .azurecr.io)
     $acrName = $Registry -replace '\.azurecr\.io$', ''
 
-    # Get ACR admin credentials
-    Write-InfoLog "Fetching ACR credentials for '$acrName'..."
-    $acrCreds = az acr credential show --name $acrName 2>&1
+    # Use the signed-in Azure identity; do not require the ACR admin account.
+    Write-InfoLog "Requesting a short-lived ACR access token for '$acrName'..."
+    $acrToken = az acr login --name $acrName --expose-token --query accessToken -o tsv --only-show-errors 2>$null
     if ($LASTEXITCODE -ne 0) {
-        Write-ErrorLog "Failed to get ACR credentials: $acrCreds"
-        Write-WarnLog "Make sure admin user is enabled on the ACR:"
-        Write-Host "  az acr update --name $acrName --admin-enabled true" -ForegroundColor Cyan
+        Write-ErrorLog "Failed to obtain an ACR access token with the current Azure CLI identity."
+        Write-WarnLog "Confirm that the signed-in identity can pull images from '$acrName'."
         return $false
     }
 
-    $creds = $acrCreds | ConvertFrom-Json
-    $acrUser = $creds.username
-    $acrPass = $creds.passwords[0].value
+    $acrUser = "00000000-0000-0000-0000-000000000000"
+    $acrPass = ($acrToken | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($acrPass)) {
+        Write-ErrorLog "Azure CLI returned an empty ACR access token."
+        return $false
+    }
 
     # Create or update the secret (using --dry-run + apply for idempotency)
     Write-InfoLog "Creating/updating K8s pull secret '$SecretName'..."
@@ -876,13 +945,18 @@ function Ensure-AcrPullSecret {
         --dry-run=client -o yaml 2>&1
 
     if ($LASTEXITCODE -ne 0) {
-        Write-ErrorLog "Failed to generate pull secret YAML: $secretYaml"
+        Write-ErrorLog "Failed to generate the Kubernetes ACR pull secret."
+        $acrPass = $null
+        $acrToken = $null
         return $false
     }
 
     $applyResult = $secretYaml | kubectl apply -f - 2>&1
+    $acrPass = $null
+    $acrToken = $null
+    $secretYaml = $null
     if ($LASTEXITCODE -ne 0) {
-        Write-ErrorLog "Failed to apply pull secret: $applyResult"
+        Write-ErrorLog "Failed to apply ACR pull secret '$SecretName': $applyResult"
         return $false
     }
 
@@ -915,9 +989,7 @@ function Deploy-Module {
     }
     
     if ($isDeployed -and $ForceRedeploy) {
-        Write-InfoLog "Force redeployment requested, deleting existing deployment..."
-        kubectl delete deployment -n default -l app=$Module 2>$null
-        Start-Sleep -Seconds 3
+        Write-InfoLog "Force redeployment requested, applying the updated deployment..."
     }
     
     # Update deployment file with container registry if configured
@@ -1194,6 +1266,19 @@ function Main {
             Write-WarnLog "Failed to create service account - deployments may fail if they require it"
         }
         Write-Host ""
+
+        # Project the AIO-managed public broker CA into the module namespace.
+        $mqttModules = @($modulesToDeploy | Where-Object { $_ -in @("edgemqttsim", "demohistorian") })
+        if ($mqttModules.Count -gt 0) {
+            Write-Host "`n========================================" -ForegroundColor Cyan
+            Write-Host "Ensuring MQTT Broker Trust Bundle" -ForegroundColor Cyan
+            Write-Host "========================================" -ForegroundColor Cyan
+            $trustBundleResult = Ensure-MqttBrokerTrustBundle -TargetNamespace "default"
+            if (-not $trustBundleResult) {
+                throw "MQTT broker CA trust bundle setup failed"
+            }
+            Write-Host ""
+        }
 
         # Ensure ACR pull secret exists (required for private Azure Container Registry)
         if ($script:ContainerRegistry) {

--- a/quickstart/external_configuration/External-Configurator.ps1
+++ b/quickstart/external_configuration/External-Configurator.ps1
@@ -205,17 +205,26 @@ function Test-Prerequisites {
         Write-ErrorLog "Azure CLI is not installed or not in PATH" -Fatal
     }
     
-    # Check for iot-ops extension
+    # Check for required CLI extensions — missing extensions cause az commands to hang indefinitely
     $extensions = az extension list --output json 2>$null | ConvertFrom-Json
-    $iotOpsExt = $extensions | Where-Object { $_.name -eq 'azure-iot-ops' }
-    
-    if (-not $iotOpsExt) {
-        Write-WarnLog "azure-iot-ops extension not found. Install it manually before continuing:"
-        Write-WarnLog "  az extension add --name azure-iot-ops --upgrade"
-        Write-WarnLog "Then re-run this script."
-        $allPassed = $false
-    } else {
-        Write-Success "azure-iot-ops extension version: $($iotOpsExt.version)"
+    $requiredCliExtensions = @('azure-iot-ops', 'connectedk8s', 'k8s-extension')
+    $missingExtensions = @()
+
+    foreach ($extName in $requiredCliExtensions) {
+        $ext = $extensions | Where-Object { $_.name -eq $extName }
+        if ($ext) {
+            Write-Success "$extName extension version: $($ext.version)"
+        } else {
+            $missingExtensions += $extName
+        }
+    }
+
+    if ($missingExtensions.Count -gt 0) {
+        Write-ErrorLog "The following required Azure CLI extensions are not installed:" -Fatal:$false
+        foreach ($extName in $missingExtensions) {
+            Write-ErrorLog "  az extension add --upgrade --name $extName" -Fatal:$false
+        }
+        Write-ErrorLog "Install the missing extensions above and re-run this script." -Fatal
     }
     
     # Check ARM templates directory
@@ -661,10 +670,18 @@ function Connect-ToAzure {
     }
 
     if (-not $script:ContainerRegistryName) {
-        # ACR names: 5-50 chars, alphanumeric only, globally unique
-        $script:ContainerRegistryName = ($clusterNameClean + "acr").Substring(0, [Math]::Min(50, ($clusterNameClean + "acr").Length))
+        # ACR names: 5-50 chars, alphanumeric only, globally unique.
+        # Append a 6-char suffix derived from the subscription ID to reduce global name collisions.
+        $suffix = ($script:SubscriptionId -replace '-', '').Substring(0, 6)
+        $baseName = $clusterNameClean + "acr" + $suffix
+        $script:ContainerRegistryName = $baseName.Substring(0, [Math]::Min(50, $baseName.Length))
         $script:ContainerRegistryLoginServer = "$($script:ContainerRegistryName).azurecr.io"
-        Write-InfoLog "Using auto-generated container registry name: $script:ContainerRegistryName"
+        Write-Host ""
+        Write-Host "  [ACR] No container_registry value was set — auto-generating a name." -ForegroundColor Yellow
+        Write-Host "  [ACR] Container Registry will be created as: $script:ContainerRegistryName" -ForegroundColor Yellow
+        Write-Host "  [ACR] To use your own name, set 'container_registry' in config/aio_config.json" -ForegroundColor Yellow
+        Write-Host "        or set `$env:AZURE_CONTAINER_REGISTRY before running this script." -ForegroundColor Yellow
+        Write-Host ""
     }
     
     if (-not $script:KeyVaultName) {

--- a/quickstart/external_configuration/grant_entra_id_roles.ps1
+++ b/quickstart/external_configuration/grant_entra_id_roles.ps1
@@ -357,6 +357,28 @@ try {
     exit 1
 }
 
+# Check for required CLI extensions — missing extensions cause az commands to hang indefinitely
+$extensions = az extension list --output json 2>$null | ConvertFrom-Json
+$requiredCliExtensions = @('azure-iot-ops', 'connectedk8s', 'k8s-extension')
+$missingExtensions = @()
+
+foreach ($extName in $requiredCliExtensions) {
+    $ext = $extensions | Where-Object { $_.name -eq $extName }
+    if ($ext) {
+        Write-Success "$extName extension version: $($ext.version)"
+    } else {
+        $missingExtensions += $extName
+    }
+}
+
+if ($missingExtensions.Count -gt 0) {
+    Write-Host "ERROR: The following required Azure CLI extensions are not installed:" -ForegroundColor Red
+    $missingExtensions | ForEach-Object { Write-Host "  az extension add --upgrade --name $_" -ForegroundColor Yellow }
+    Write-Host "Install the missing extensions above and re-run this script." -ForegroundColor Red
+    Stop-Transcript
+    exit 1
+}
+
 # ============================================================================
 # AZURE AUTHENTICATION
 # ============================================================================

--- a/quickstart/modules/README.md
+++ b/quickstart/modules/README.md
@@ -1,418 +1,331 @@
 # IoT Operations Applications
 
-This directory contains containerized applications designed to be deployed to Azure IoT Operations Kubernetes clusters running on edge devices.
+This directory contains containerized applications designed to be deployed to
+Azure IoT Operations Kubernetes clusters running on edge devices.
 
-These are for demo purposes mostly but can be used to test and validate your IoT Operations build. 
+These are mostly for demo purposes but can also be used to test and validate an
+IoT Operations build.
 
 ## Available Applications
 
-### � sputnik
-An MQTT publisher that sends periodic "beep" messages to the Azure IoT Operations MQTT broker.
+### Edge MQTT simulator
+
+An MQTT publisher that generates realistic factory telemetry for Azure IoT
+Operations.
 
 **Features:**
+
 - MQTT v5 with ServiceAccountToken (K8S-SAT) authentication
-- Sends timestamped beep messages every 5 seconds
-- Demonstrates in-cluster MQTT publishing
-- Auto-reconnection and error handling
+- Configurable industrial equipment and business-event messages
+- Topic-based routing for factory telemetry
+- Automatic reconnection and message buffering
 
-**Quick Deploy:** Automatically deployed via GitHub Actions when pushing to `dev` branch
-  
-[📖 Read the docs →](./sputnik/README.md)
+**Quick Deploy:**
 
-### 👂 mosquitto-sub
-An MQTT subscriber that displays messages from the Azure IoT Operations MQTT broker in real-time.
- 
+```powershell
+.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username"
+```
+
+[Read the docs](./edgemqttsim/README.md)
+
+### Demo historian
+
+An MQTT subscriber that stores factory telemetry in PostgreSQL and exposes a
+query API.
+
 **Features:**
-- Subscribe to any MQTT topic (with wildcard support)
-- Uses official eclipse-mosquitto image (no build needed)
-- Same K8S-SAT authentication as Sputnik
-- Perfect for testing and debugging MQTT message flow
 
-**Quick Deploy:** Automatically deployed via GitHub Actions when pushing to `dev` branch
+- MQTT v5 with ServiceAccountToken (K8S-SAT) authentication
+- Wildcard MQTT subscriptions
+- PostgreSQL message history and retention
+- HTTP health and query endpoints
 
-**View Messages:** `kubectl logs -n default -l app=mosquitto-sub -f`
-  
-[📖 Read the docs →](./mosquitto-sub/README.md) | [⚡ Quick Start →](./mosquitto-sub/QUICKSTART.md)
+**Quick Deploy:**
 
-### �📦 hello-flask
-A simple Flask "Hello World" REST API that demonstrates:
-- Container deployment to IoT Operations
-- Remote deployment from Windows to edge devices
-- Using `uv` for Python dependency management
-- Kubernetes service exposure on local networks
-- Health checks and monitoring
+```powershell
+.\Deploy-ToIoTEdge.ps1 -AppFolder "demohistorian" -RegistryName "your-username"
+```
 
-**Quick Deploy:** `.\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "your-username"`
-  
-[📖 Read the docs →](./hello-flask/README.md)
+[Read the docs](./demohistorian/README.md)
 
 ## Deployment Scripts
 
-This folder contains three modular PowerShell deployment scripts that work with any application in the `iotopps` folder:
+This folder contains three modular PowerShell deployment scripts that work with
+applications in the modules folder.
 
-### 📤 Deploy-ToIoTEdge.ps1
-Deploy applications to remote IoT Operations clusters via Azure Arc.
+### Deploy-ToIoTEdge.ps1
+
+Deploy applications to remote IoT Operations clusters through Azure Arc.
 
 **Usage:**
+
 ```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "your-username"
-.\Deploy-ToIoTEdge.ps1 -AppFolder "my-app" -RegistryName "myacr" -RegistryType "acr" -ImageTag "v1.0"
+.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username"
+.\Deploy-ToIoTEdge.ps1 -AppFolder "demohistorian" -RegistryName "myacr" -RegistryType "acr" -ImageTag "v1.0"
 ```
 
 **Parameters:**
-- `-AppFolder` (Required): Name of the app folder to deploy
-- `-RegistryName` (Required): Docker Hub username or ACR name
-- `-RegistryType`: `dockerhub` or `acr` (default: dockerhub)
-- `-ImageTag`: Image tag (default: latest)
-- `-SkipBuild`: Skip Docker build/push (use existing image)
-- `-EdgeDeviceIP`: Direct SSH connection fallback
-- `-ConfigPath`: Override default config location
 
-### 🏠 Deploy-Local.ps1
+- `-AppFolder` (required): Name of the application folder to deploy
+- `-RegistryName` (required): Docker Hub username or ACR name
+- `-RegistryType`: `dockerhub` or `acr` (default: `dockerhub`)
+- `-ImageTag`: Image tag (default: `latest`)
+- `-SkipBuild`: Skip Docker build and push and use an existing image
+- `-EdgeDeviceIP`: Direct SSH connection fallback
+- `-ConfigPath`: Override the default configuration location
+
+### Deploy-Local.ps1
+
 Run applications locally for development and testing.
 
 **Usage:**
+
 ```powershell
-.\Deploy-Local.ps1 -AppFolder "hello-flask"
-.\Deploy-Local.ps1 -AppFolder "my-app" -Mode docker -Port 8080
-.\Deploy-Local.ps1 -AppFolder "hello-flask" -Mode python -Clean
+.\Deploy-Local.ps1 -AppFolder "edgemqttsim"
+.\Deploy-Local.ps1 -AppFolder "demohistorian" -Mode docker -Port 8080
+.\Deploy-Local.ps1 -AppFolder "edgemqttsim" -Mode python -Clean
 ```
 
 **Parameters:**
-- `-AppFolder` (Required): Name of the app folder to run
-- `-Mode`: `python`, `docker`, `uv`, or `auto` (default: auto)
-- `-Port`: Local port (default: 5000)
-- `-Build`: Force Docker rebuild
-- `-Clean`: Clean Python venv before setup
 
-### 🔍 Deploy-Check.ps1
-Check deployment status and health of deployed applications.
+- `-AppFolder` (required): Name of the application folder to run
+- `-Mode`: `python`, `docker`, `uv`, or `auto` (default: `auto`)
+- `-Port`: Local port (default: `5000`)
+- `-Build`: Force a Docker rebuild
+- `-Clean`: Clean the Python virtual environment before setup
+
+### Deploy-Check.ps1
+
+Check deployment status and health for deployed applications.
 
 **Usage:**
+
 ```powershell
-.\Deploy-Check.ps1 -AppFolder "hello-flask"
-.\Deploy-Check.ps1 -AppFolder "my-app" -EdgeDeviceIP "192.168.1.100"
+.\Deploy-Check.ps1 -AppFolder "edgemqttsim"
+.\Deploy-Check.ps1 -AppFolder "demohistorian" -EdgeDeviceIP "192.168.1.100"
 ```
 
 **Parameters:**
-- `-AppFolder` (Required): Name of the app folder to check
-- `-EdgeDeviceIP`: Direct connection to edge device
-- `-ConfigPath`: Override default config location
+
+- `-AppFolder` (required): Name of the application folder to check
+- `-EdgeDeviceIP`: Direct connection to the edge device
+- `-ConfigPath`: Override the default configuration location
 
 ## Deployment Workflows
 
-### Two-Machine Workflow (Docker on one machine, Kubernetes access on another)
+### Two-Machine Workflow
 
-If you have Docker and Kubernetes access on separate machines:
+Use this workflow when Docker and Kubernetes access are on separate machines.
 
 **On the machine with Docker:**
-1. Build and push your container image to Docker Hub or ACR (see "Build and Push Container Images Manually" section below)
-2. Note the full image name (e.g., `username/hello-flask:latest`)
 
-**On the machine with Kubernetes/Arc access:**
-1. Run the deployment script with `-SkipBuild` to deploy the pre-built image:
+1. Build and push the container image to Docker Hub or ACR.
+2. Note the full image name, such as `username/edgemqttsim:latest`.
+
+**On the machine with Kubernetes or Arc access:**
+
+Run the deployment script with `-SkipBuild`:
+
+```powershell
+.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username" -SkipBuild
+```
+
+The script detects whether Docker is missing and provides instructions for
+manual image building.
+
+### Remote Deployment
+
+Deploy applications from a Windows development machine to a remote IoT
+Operations cluster:
+
+1. Configure the cluster in `../config/aio_config.json`.
+2. Run the deployment script from the modules folder:
+
    ```powershell
-   .\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "your-username" -SkipBuild
-   ```
-
-The script will detect if Docker is missing and provide instructions for manual image building.
-
-### Remote Deployment (Windows → Edge Device)
-Deploy applications from your Windows development machine to remote IoT Operations clusters:
-
-1. Configure your cluster in `../config/aio_config.json`
-2. From the `iotopps` folder, run the deployment script:
-   ```powershell
-   .\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "your-registry"
+   .\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-registry"
    ```
 
 The script handles:
-- ✓ Building Docker images
-- ✓ Pushing to container registry
-- ✓ Connecting to Arc-enabled clusters
-- ✓ Deploying to Kubernetes
-- ✓ Verifying deployment status
+
+- Building Docker images
+- Pushing images to the container registry
+- Connecting to Arc-enabled clusters
+- Deploying to Kubernetes
+- Verifying deployment status
 
 ### Local Development
-Test applications locally before deploying:
 
-1. From the `iotopps` folder, run:
-   ```powershell
-   .\Deploy-Local.ps1 -AppFolder "hello-flask"
-   ```
-2. Access at `http://localhost:5000`
-
-### Check Deployment Status
-Monitor your deployed applications:
+Run an application locally before deploying:
 
 ```powershell
-.\Deploy-Check.ps1 -AppFolder "hello-flask"
+.\Deploy-Local.ps1 -AppFolder "edgemqttsim"
+```
+
+### Check Deployment Status
+
+```powershell
+.\Deploy-Check.ps1 -AppFolder "edgemqttsim"
 ```
 
 ## Prerequisites
 
-### For Remote Deployment
-- **Docker Desktop (Windows/Mac)** - Optional if using two-machine workflow (see below)
+### Remote Deployment
+
+- Docker Desktop on Windows or macOS, unless using the two-machine workflow
 - Azure CLI (`az`)
-- kubectl
-- Access to container registry (Docker Hub or ACR)
-- Azure IoT Operations deployed and Arc-connected
+- `kubectl`
+- Access to a container registry
+- Azure IoT Operations deployed and connected to Azure Arc
 
-**Two-Machine Setup:**
-- Machine 1 (Build): Docker Desktop for building images
-- Machine 2 (Deploy): Azure CLI + kubectl for deployment (no Docker needed)
-- Both machines need access to the same container registry
+### Local Development
 
-### For Local Development
-- Python 3.8+ OR Docker OR uv
-- Application dependencies (see app-specific requirements.txt)
+- Python 3.8 or later, Docker, or `uv`
+- Application dependencies from the module's `requirements.txt`
 
 ## Project Structure
 
-```
-iotopps/
-├── README.md                    # This file
-├── Deploy-ToIoTEdge.ps1        # Modular remote deployment script
-├── Deploy-Local.ps1             # Modular local development script
-├── Deploy-Check.ps1             # Modular deployment status checker
-├── .vscode/
-│   └── settings.json           # VS Code settings (uses uv for Python)
-└── hello-flask/                # Flask Hello World app
-    ├── app.py                  # Flask application
-    ├── Dockerfile              # Container definition (uses uv)
-    ├── requirements.txt        # Python dependencies
-    ├── deployment.yaml         # Kubernetes manifest
-    ├── hello_flask_config.json # App-specific configuration (optional)
-    ├── README.md               # Full documentation
-    ├── QUICKSTART.md           # Quick start guide
-    └── FILE-GUIDE.md           # File descriptions
+```text
+modules/
+├── README.md
+├── Deploy-ToIoTEdge.ps1
+├── Deploy-Local.ps1
+├── Deploy-Check.ps1
+├── edgemqttsim/
+│   ├── app.py
+│   ├── Dockerfile
+│   ├── requirements.txt
+│   ├── deployment.yaml
+│   ├── message_structure.yaml
+│   └── README.md
+└── demohistorian/
+    ├── app.py
+    ├── Dockerfile
+    ├── requirements.txt
+    ├── deployment.yaml
+    ├── config.yaml
+    └── README.md
 ```
 
 ## Configuration
 
 ### Cluster Configuration
-Your IoT Operations cluster configuration is stored in:
-```
+
+The IoT Operations cluster configuration is stored in:
+
+```text
 ../config/aio_config.json
 ```
 
 This file contains:
+
 - Azure subscription details
 - Resource group name
 - Cluster name and location
 - Deployment preferences
 
-All deployment scripts automatically read this configuration.
+The deployment scripts read this configuration automatically.
 
-### Application Configuration (Optional)
-Each application can have its own config file (e.g., `hello_flask_config.json`) containing:
-- Registry settings (type, name)
+### Application Configuration
+
+Each application can provide its own configuration for settings such as:
+
+- Registry type and name
 - Image tags
-- Development preferences (port, runtime mode)
+- Development port and runtime preferences
 
 ## Common Commands
 
-### Build and Push Container Images Manually
+### Build and Push to Docker Hub
 
-If you have Docker on a separate machine from your Kubernetes cluster access, you can build and push images manually:
-
-#### For Docker Hub:
 ```bash
-# Navigate to your app folder
-cd iotopps/hello-flask
-
-# Build the image
-docker build -t hello-flask:latest .
-
-# Tag for your registry
-docker tag hello-flask:latest YOUR-DOCKERHUB-USERNAME/hello-flask:latest
-
-# Login to Docker Hub
+cd modules/edgemqttsim
+docker build -t edgemqttsim:latest .
+docker tag edgemqttsim:latest YOUR-DOCKERHUB-USERNAME/edgemqttsim:latest
 docker login
-
-# Push to Docker Hub
-docker push YOUR-DOCKERHUB-USERNAME/hello-flask:latest
+docker push YOUR-DOCKERHUB-USERNAME/edgemqttsim:latest
 ```
 
-#### For Azure Container Registry (ACR):
+### Build and Push to Azure Container Registry
+
 ```bash
-# Navigate to your app folder
-cd iotopps/hello-flask
-
-# Build the image
-docker build -t hello-flask:latest .
-
-# Tag for ACR
-docker tag hello-flask:latest YOUR-ACR-NAME.azurecr.io/hello-flask:latest
-
-# Login to ACR (requires Azure CLI)
+cd modules/edgemqttsim
+docker build -t edgemqttsim:latest .
+docker tag edgemqttsim:latest YOUR-ACR-NAME.azurecr.io/edgemqttsim:latest
 az acr login --name YOUR-ACR-NAME
-
-# Push to ACR
-docker push YOUR-ACR-NAME.azurecr.io/hello-flask:latest
+docker push YOUR-ACR-NAME.azurecr.io/edgemqttsim:latest
 ```
 
-After pushing the image, you can deploy it from a machine without Docker using:
+After pushing the image, deploy it from a machine without Docker:
+
 ```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "YOUR-USERNAME" -SkipBuild
+.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "YOUR-USERNAME" -SkipBuild
 ```
 
 ### Deploy an Application
-```powershell
-# Deploy to IoT Edge cluster
-.\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "myusername"
 
-# Deploy with custom tag
-.\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "myusername" -ImageTag "v1.0"
+```powershell
+.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "myusername"
+.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "myusername" -ImageTag "v1.0"
 ```
 
 ### Check Application Status
+
 ```powershell
-.\Deploy-Check.ps1 -AppFolder "hello-flask"
+.\Deploy-Check.ps1 -AppFolder "edgemqttsim"
 ```
 
 ### Run Locally
-```powershell
-# Auto-detect runtime (uv > docker > python)
-.\Deploy-Local.ps1 -AppFolder "hello-flask"
 
-# Specify runtime
-.\Deploy-Local.ps1 -AppFolder "hello-flask" -Mode docker
+```powershell
+.\Deploy-Local.ps1 -AppFolder "edgemqttsim"
+.\Deploy-Local.ps1 -AppFolder "edgemqttsim" -Mode docker
 ```
 
 ### View Application Logs
+
 ```bash
-kubectl logs -l app=hello-flask
+kubectl logs -n default -l app=edgemqttsim -f
 ```
 
-### Access Applications
-Applications are exposed via NodePort on the edge device's network:
-```
-http://<edge-device-ip>:30080
-```
+### Update an Application
 
-### Update Application
-1. Modify source code in the app folder
-2. Redeploy with new tag:
-   ```powershell
-   .\Deploy-ToIoTEdge.ps1 -AppFolder "hello-flask" -RegistryName "your-username" -ImageTag "v1.1"
-   ```
+Modify the source and redeploy with a new tag:
+
+```powershell
+.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username" -ImageTag "v1.1"
+```
 
 ## Adding New Applications
 
-To add a new application to this directory:
+To add an application:
 
-1. **Create Application Folder**
-   ```powershell
-   mkdir iotopps\my-new-app
-   cd iotopps\my-new-app
-   ```
-
-2. **Add Required Files**
-   - Application code (e.g., `app.py`, `main.py`)
-   - `Dockerfile` - Container definition
-   - `deployment.yaml` - Kubernetes manifest
-   - `requirements.txt` - Dependencies (if Python)
-
-3. **Create Kubernetes Deployment Manifest**
-   ```yaml
-   # deployment.yaml
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: my-new-app
-   spec:
-     replicas: 1
-     selector:
-       matchLabels:
-         app: my-new-app
-     template:
-       metadata:
-         labels:
-           app: my-new-app
-       spec:
-         containers:
-         - name: my-new-app
-           image: <YOUR_REGISTRY>/my-new-app:latest
-           ports:
-           - containerPort: 5000
-   ---
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: my-new-app-service
-   spec:
-     type: NodePort
-     selector:
-       app: my-new-app
-     ports:
-     - port: 80
-       targetPort: 5000
-       nodePort: 30081
-   ```
-
-4. **Optional: Add App Config**
-   Create `my_new_app_config.json` for default settings:
-   ```json
-   {
-     "registry": {
-       "type": "dockerhub",
-       "name": "your-username"
-     },
-     "image": {
-       "tag": "latest"
-     },
-     "development": {
-       "localPort": 5000,
-       "preferredRuntime": "auto"
-     }
-   }
-   ```
-
-5. **Deploy Your Application**
-   ```powershell
-   # From iotopps folder
-   .\Deploy-Local.ps1 -AppFolder "my-new-app"
-   .\Deploy-ToIoTEdge.ps1 -AppFolder "my-new-app" -RegistryName "your-username"
-   ```
-
-6. **Update Documentation**
-   - Add your app to the "Available Applications" section in this README
-   - Create an app-specific README in your app folder
-
-### Application Requirements
-- **Dockerfile**: Must expose the application port
-- **deployment.yaml**: Must use `<YOUR_REGISTRY>` placeholder for registry name
-- **Service naming**: Use `{app-name}-service` convention
-- **Labels**: Use `app: {app-name}` for pod selection
+1. Create a folder under `modules`.
+2. Add the application code, `Dockerfile`, `deployment.yaml`, and dependency
+   file.
+3. Use `<YOUR_REGISTRY>` in the deployment manifest image name.
+4. Use the `app: {app-name}` label for pod selection.
+5. Add an application README and an entry to this document.
+6. Deploy it with `Deploy-ToIoTEdge.ps1`.
 
 ## Technology Stack
 
-- **Container Runtime**: Docker
-- **Orchestration**: Kubernetes (K3s)
-- **Python Package Manager**: `uv` (fast, modern)
-- **Edge Platform**: Azure IoT Operations
-- **Cloud Integration**: Azure Arc
+- **Container runtime:** Docker
+- **Orchestration:** Kubernetes (K3s)
+- **Python package manager:** `uv`
+- **Edge platform:** Azure IoT Operations
+- **Cloud integration:** Azure Arc
 
 ## Related Documentation
 
-- [Linux Build Steps](../../linux_build/linux_build_steps.md) - Setting up IoT Operations
-- [K3s Troubleshooting](../../linux_build/K3S_TROUBLESHOOTING_GUIDE.md) - Cluster issues
-- [Project README](../../readme.md) - Overall project documentation
-
-## Next Steps
-
-- ✅ Deploy your first application (hello-flask)
-- 🔄 Integrate with MQTT broker for IoT messaging
-- 📊 Add monitoring and observability
-- 🔒 Implement security best practices
-- 🚀 Set up CI/CD pipelines
-- 📦 Create additional applications
+- [Project README](../../README.md)
+- [Edge MQTT simulator](./edgemqttsim/README.md)
+- [Demo historian](./demohistorian/README.md)
 
 ## Support
 
 For issues or questions:
-1. Check application-specific README files
-2. Review troubleshooting guides in `linux_build/`
-3. Check Azure IoT Operations documentation
-4. Review Kubernetes logs and events
+
+1. Check the application-specific README.
+2. Review the quickstart documentation.
+3. Check the Azure IoT Operations documentation.
+4. Review Kubernetes logs and events.

--- a/quickstart/modules/README.md
+++ b/quickstart/modules/README.md
@@ -1,331 +1,111 @@
-# IoT Operations Applications
+# IoT Operations Demo Applications
 
-This directory contains containerized applications designed to be deployed to
-Azure IoT Operations Kubernetes clusters running on edge devices.
+This directory contains containerized demo applications for Azure IoT Operations
+Kubernetes clusters running on edge devices.
 
-These are mostly for demo purposes but can also be used to test and validate an
-IoT Operations build.
-
-## Available Applications
+## Applications
 
 ### Edge MQTT simulator
 
-An MQTT publisher that generates realistic factory telemetry for Azure IoT
-Operations.
+`edgemqttsim` publishes configurable factory telemetry to the Azure IoT Operations
+MQTT broker with MQTT v5 and K8S-SAT authentication.
 
-**Features:**
-
-- MQTT v5 with ServiceAccountToken (K8S-SAT) authentication
-- Configurable industrial equipment and business-event messages
-- Topic-based routing for factory telemetry
-- Automatic reconnection and message buffering
-
-**Quick Deploy:**
-
-```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username"
-```
-
-[Read the docs](./edgemqttsim/README.md)
+[Edge MQTT simulator documentation](./edgemqttsim/README.md)
 
 ### Demo historian
 
-An MQTT subscriber that stores factory telemetry in PostgreSQL and exposes a
-query API.
+`demohistorian` subscribes to factory MQTT topics, stores messages in PostgreSQL,
+and exposes health and query endpoints.
 
-**Features:**
-
-- MQTT v5 with ServiceAccountToken (K8S-SAT) authentication
-- Wildcard MQTT subscriptions
-- PostgreSQL message history and retention
-- HTTP health and query endpoints
-
-**Quick Deploy:**
-
-```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "demohistorian" -RegistryName "your-username"
-```
-
-[Read the docs](./demohistorian/README.md)
-
-## Deployment Scripts
-
-This folder contains three modular PowerShell deployment scripts that work with
-applications in the modules folder.
-
-### Deploy-ToIoTEdge.ps1
-
-Deploy applications to remote IoT Operations clusters through Azure Arc.
-
-**Usage:**
-
-```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username"
-.\Deploy-ToIoTEdge.ps1 -AppFolder "demohistorian" -RegistryName "myacr" -RegistryType "acr" -ImageTag "v1.0"
-```
-
-**Parameters:**
-
-- `-AppFolder` (required): Name of the application folder to deploy
-- `-RegistryName` (required): Docker Hub username or ACR name
-- `-RegistryType`: `dockerhub` or `acr` (default: `dockerhub`)
-- `-ImageTag`: Image tag (default: `latest`)
-- `-SkipBuild`: Skip Docker build and push and use an existing image
-- `-EdgeDeviceIP`: Direct SSH connection fallback
-- `-ConfigPath`: Override the default configuration location
-
-### Deploy-Local.ps1
-
-Run applications locally for development and testing.
-
-**Usage:**
-
-```powershell
-.\Deploy-Local.ps1 -AppFolder "edgemqttsim"
-.\Deploy-Local.ps1 -AppFolder "demohistorian" -Mode docker -Port 8080
-.\Deploy-Local.ps1 -AppFolder "edgemqttsim" -Mode python -Clean
-```
-
-**Parameters:**
-
-- `-AppFolder` (required): Name of the application folder to run
-- `-Mode`: `python`, `docker`, `uv`, or `auto` (default: `auto`)
-- `-Port`: Local port (default: `5000`)
-- `-Build`: Force a Docker rebuild
-- `-Clean`: Clean the Python virtual environment before setup
-
-### Deploy-Check.ps1
-
-Check deployment status and health for deployed applications.
-
-**Usage:**
-
-```powershell
-.\Deploy-Check.ps1 -AppFolder "edgemqttsim"
-.\Deploy-Check.ps1 -AppFolder "demohistorian" -EdgeDeviceIP "192.168.1.100"
-```
-
-**Parameters:**
-
-- `-AppFolder` (required): Name of the application folder to check
-- `-EdgeDeviceIP`: Direct connection to the edge device
-- `-ConfigPath`: Override the default configuration location
-
-## Deployment Workflows
-
-### Two-Machine Workflow
-
-Use this workflow when Docker and Kubernetes access are on separate machines.
-
-**On the machine with Docker:**
-
-1. Build and push the container image to Docker Hub or ACR.
-2. Note the full image name, such as `username/edgemqttsim:latest`.
-
-**On the machine with Kubernetes or Arc access:**
-
-Run the deployment script with `-SkipBuild`:
-
-```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username" -SkipBuild
-```
-
-The script detects whether Docker is missing and provides instructions for
-manual image building.
-
-### Remote Deployment
-
-Deploy applications from a Windows development machine to a remote IoT
-Operations cluster:
-
-1. Configure the cluster in `../config/aio_config.json`.
-2. Run the deployment script from the modules folder:
-
-   ```powershell
-   .\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-registry"
-   ```
-
-The script handles:
-
-- Building Docker images
-- Pushing images to the container registry
-- Connecting to Arc-enabled clusters
-- Deploying to Kubernetes
-- Verifying deployment status
-
-### Local Development
-
-Run an application locally before deploying:
-
-```powershell
-.\Deploy-Local.ps1 -AppFolder "edgemqttsim"
-```
-
-### Check Deployment Status
-
-```powershell
-.\Deploy-Check.ps1 -AppFolder "edgemqttsim"
-```
+[Demo historian documentation](./demohistorian/README.md)
 
 ## Prerequisites
 
-### Remote Deployment
+- Azure IoT Operations installed on an Arc-connected Kubernetes cluster
+- Azure CLI and `kubectl`
+- An `aio_config.json` file for the target environment
+- A container registry configured in `aio_config.json`
 
-- Docker Desktop on Windows or macOS, unless using the two-machine workflow
-- Azure CLI (`az`)
-- `kubectl`
-- Access to a container registry
-- Azure IoT Operations deployed and connected to Azure Arc
+Docker is not required on the management machine when the configured registry is
+Azure Container Registry. The deployment script uses ACR cloud builds.
 
-### Local Development
+## Quick Deploy
 
-- Python 3.8 or later, Docker, or `uv`
-- Application dependencies from the module's `requirements.txt`
+Run the tracked deployment script from the repository root and select one module:
+
+```powershell
+.\quickstart\external_configuration\Deploy-EdgeModules.ps1 -ConfigPath "<path-to-aio_config.json>" -ModuleName edgemqttsim -Force
+.\quickstart\external_configuration\Deploy-EdgeModules.ps1 -ConfigPath "<path-to-aio_config.json>" -ModuleName demohistorian -Force
+```
+
+The script:
+
+1. Loads cluster and registry settings from `aio_config.json`.
+2. Builds and pushes the selected image.
+3. Connects to the cluster through Azure Arc.
+4. Ensures the `mqtt-client` service account and registry pull secret.
+5. Refreshes the AIO-managed MQTT broker CA trust bundle in `default`.
+6. Applies the module's `deployment.yaml`.
+7. Reports deployment status and log commands.
+
+Use `-SkipBuild` only when the updated image already exists in the configured
+registry.
+
+## MQTT Security
+
+Both modules use the projected Kubernetes ServiceAccount token at
+`/var/run/secrets/tokens/broker-sat`. Before reading or sending that token, each
+client validates the MQTT broker certificate with
+`/var/run/certs/ca.crt`.
+
+For the default listener on port `18883`, Azure IoT Operations manages the broker
+certificate and public trust bundle with cert-manager and trust-manager. The
+deployment script projects that managed trust bundle into the `default` namespace
+for these demo workloads. Custom Key Vault-backed certificates should be delivered
+to Kubernetes through AIO SecretSync rather than copied directly by an application.
+
+If the CA is missing, unreadable, empty, or invalid, the application logs the
+specific certificate problem and refuses the K8S-SAT MQTT connection.
+
+## Observe the Demo
+
+```powershell
+kubectl get pods -n default -l app=edgemqttsim
+kubectl get pods -n default -l app=demohistorian
+kubectl logs -n default -l app=edgemqttsim -f
+kubectl logs -n default -l app=demohistorian -c historian -f
+```
+
+The simulator logs published telemetry. The historian logs its MQTT connection,
+subscription, and received message activity.
 
 ## Project Structure
 
 ```text
 modules/
 ├── README.md
-├── Deploy-ToIoTEdge.ps1
-├── Deploy-Local.ps1
-├── Deploy-Check.ps1
 ├── edgemqttsim/
 │   ├── app.py
-│   ├── Dockerfile
-│   ├── requirements.txt
 │   ├── deployment.yaml
+│   ├── Dockerfile
 │   ├── message_structure.yaml
+│   ├── requirements.txt
 │   └── README.md
 └── demohistorian/
     ├── app.py
+    ├── config.yaml
+    ├── deployment.yaml
     ├── Dockerfile
     ├── requirements.txt
-    ├── deployment.yaml
-    ├── config.yaml
     └── README.md
 ```
 
-## Configuration
-
-### Cluster Configuration
-
-The IoT Operations cluster configuration is stored in:
-
-```text
-../config/aio_config.json
-```
-
-This file contains:
-
-- Azure subscription details
-- Resource group name
-- Cluster name and location
-- Deployment preferences
-
-The deployment scripts read this configuration automatically.
-
-### Application Configuration
-
-Each application can provide its own configuration for settings such as:
-
-- Registry type and name
-- Image tags
-- Development port and runtime preferences
-
-## Common Commands
-
-### Build and Push to Docker Hub
-
-```bash
-cd modules/edgemqttsim
-docker build -t edgemqttsim:latest .
-docker tag edgemqttsim:latest YOUR-DOCKERHUB-USERNAME/edgemqttsim:latest
-docker login
-docker push YOUR-DOCKERHUB-USERNAME/edgemqttsim:latest
-```
-
-### Build and Push to Azure Container Registry
-
-```bash
-cd modules/edgemqttsim
-docker build -t edgemqttsim:latest .
-docker tag edgemqttsim:latest YOUR-ACR-NAME.azurecr.io/edgemqttsim:latest
-az acr login --name YOUR-ACR-NAME
-docker push YOUR-ACR-NAME.azurecr.io/edgemqttsim:latest
-```
-
-After pushing the image, deploy it from a machine without Docker:
+## Troubleshooting
 
 ```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "YOUR-USERNAME" -SkipBuild
+kubectl describe pod -n default -l app=edgemqttsim
+kubectl describe pod -n default -l app=demohistorian
+kubectl get configmap azure-iot-operations-aio-ca-trust-bundle -n default
 ```
 
-### Deploy an Application
-
-```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "myusername"
-.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "myusername" -ImageTag "v1.0"
-```
-
-### Check Application Status
-
-```powershell
-.\Deploy-Check.ps1 -AppFolder "edgemqttsim"
-```
-
-### Run Locally
-
-```powershell
-.\Deploy-Local.ps1 -AppFolder "edgemqttsim"
-.\Deploy-Local.ps1 -AppFolder "edgemqttsim" -Mode docker
-```
-
-### View Application Logs
-
-```bash
-kubectl logs -n default -l app=edgemqttsim -f
-```
-
-### Update an Application
-
-Modify the source and redeploy with a new tag:
-
-```powershell
-.\Deploy-ToIoTEdge.ps1 -AppFolder "edgemqttsim" -RegistryName "your-username" -ImageTag "v1.1"
-```
-
-## Adding New Applications
-
-To add an application:
-
-1. Create a folder under `modules`.
-2. Add the application code, `Dockerfile`, `deployment.yaml`, and dependency
-   file.
-3. Use `<YOUR_REGISTRY>` in the deployment manifest image name.
-4. Use the `app: {app-name}` label for pod selection.
-5. Add an application README and an entry to this document.
-6. Deploy it with `Deploy-ToIoTEdge.ps1`.
-
-## Technology Stack
-
-- **Container runtime:** Docker
-- **Orchestration:** Kubernetes (K3s)
-- **Python package manager:** `uv`
-- **Edge platform:** Azure IoT Operations
-- **Cloud integration:** Azure Arc
-
-## Related Documentation
-
-- [Project README](../../README.md)
-- [Edge MQTT simulator](./edgemqttsim/README.md)
-- [Demo historian](./demohistorian/README.md)
-
-## Support
-
-For issues or questions:
-
-1. Check the application-specific README.
-2. Review the quickstart documentation.
-3. Check the Azure IoT Operations documentation.
-4. Review Kubernetes logs and events.
+Check the application-specific README and pod events for additional guidance.

--- a/quickstart/modules/demohistorian/README.md
+++ b/quickstart/modules/demohistorian/README.md
@@ -80,38 +80,16 @@ The Edge Historian is a containerized service that:
 ### Quick Deploy
 
 ```powershell
-# 1. Enable in configuration
-# Edit: linux_build/aio_config.json
-# Set: "demohistorian": true in modules section
+.\quickstart\external_configuration\Deploy-EdgeModules.ps1 -ConfigPath "<path-to-aio_config.json>" -ModuleName demohistorian -Force
 
-# 2. Deploy using automation script
-cd linux_build
-.\Deploy-EdgeModules.ps1 -ModuleName demohistorian
-
-# 3. Verify deployment
+# Verify deployment
 kubectl get pods -n default -l app=demohistorian
 kubectl logs -n default -l app=demohistorian -c historian -f
 ```
 
-### Manual Deployment
-
-```bash
-# Build and push container
-docker build -t <registry>/demohistorian:latest .
-docker push <registry>/demohistorian:latest
-
-# Update deployment.yaml with your registry
-sed -i 's|<YOUR_REGISTRY>|<registry>|g' deployment.yaml
-
-# Create BrokerAuthorization (CRITICAL - required for wildcard subscription)
-kubectl apply -f ../../linux_build/assets/historian-authorization.yaml
-
-# Deploy to cluster
-kubectl apply -f deployment.yaml
-
-# Check status
-kubectl get pods -n default -l app=demohistorian
-```
+The deployment script refreshes the AIO-managed MQTT broker CA trust bundle in
+`default` and mounts it automatically. When the configured registry is ACR, the
+script builds in ACR and does not require local Docker.
 
 ## BrokerAuthorization Setup
 
@@ -276,6 +254,7 @@ MQTT_BROKER=aio-broker.azure-iot-operations.svc.cluster.local
 MQTT_PORT=18883
 MQTT_AUTH_METHOD=K8S-SAT
 SAT_TOKEN_PATH=/var/run/secrets/tokens/broker-sat
+MQTT_CA_CERT_PATH=/var/run/certs/ca.crt
 
 # Database Configuration
 POSTGRES_HOST=localhost

--- a/quickstart/modules/demohistorian/app.py
+++ b/quickstart/modules/demohistorian/app.py
@@ -50,6 +50,7 @@ def load_config() -> Dict[str, Any]:
                 'reconnect_delay': 5,
                 'protocol_version': 5,
                 'sat_token_path': '/var/run/secrets/tokens/broker-sat',
+                'ca_cert_path': '/var/run/certs/ca.crt',
                 'sat_audience': 'aio-internal',
                 'client_id_prefix': 'historian'
             },
@@ -73,6 +74,10 @@ def load_config() -> Dict[str, Any]:
     config['mqtt']['port'] = int(os.getenv('MQTT_PORT', config['mqtt']['port']))
     config['mqtt']['auth_method'] = os.getenv('MQTT_AUTH_METHOD', config['mqtt']['auth_method'])
     config['mqtt']['sat_token_path'] = os.getenv('SAT_TOKEN_PATH', config['mqtt']['sat_token_path'])
+    config['mqtt']['ca_cert_path'] = os.getenv(
+        'MQTT_CA_CERT_PATH',
+        config['mqtt'].get('ca_cert_path', '/var/run/certs/ca.crt')
+    )
     
     # Allow disabling MQTT for local testing
     config['mqtt']['enabled'] = os.getenv('MQTT_ENABLED', 'true').lower() in ('true', '1', 'yes')
@@ -441,32 +446,71 @@ class MQTTSubscriber:
         self.client.on_disconnect = self._on_disconnect
         self.client.on_message = self._on_message
         
-        # Configure K8S-SAT authentication
+        # Configure TLS before reading authentication material
         if mqtt_config['auth_method'] == 'K8S-SAT':
+            self._setup_tls()
             self._setup_sat_auth()
-        else:
+        elif mqtt_config['auth_method'].lower() == 'none':
+            if mqtt_config['port'] == 18883 or mqtt_config.get('use_tls', False):
+                self._setup_tls()
             logger.info("MQTT authentication disabled (local testing mode)")
-        
-        # Configure TLS (required for IoT Operations broker, optional for local testing)
-        if mqtt_config['port'] == 18883 or mqtt_config.get('use_tls', False):
-            self.client.tls_set(cert_reqs=ssl.CERT_NONE)
+        else:
+            raise ValueError(f"Unsupported MQTT authentication method: {mqtt_config['auth_method']}")
         
         logger.info(f"MQTT client initialized with ID: {client_id}")
+
+    def _setup_tls(self):
+        """Configure server-authenticated TLS for the MQTT connection."""
+        ca_path = Path(self.config['mqtt']['ca_cert_path'])
+
+        if not ca_path.exists():
+            logger.error(f"MQTT broker CA certificate not found at {ca_path}; refusing K8S-SAT MQTT connection")
+            raise RuntimeError("MQTT broker CA certificate is unavailable")
+
+        try:
+            if not ca_path.is_file():
+                raise OSError
+            ca_contents = ca_path.read_bytes()
+        except OSError:
+            logger.error(f"MQTT broker CA certificate at {ca_path} is unreadable; refusing K8S-SAT MQTT connection")
+            raise RuntimeError("MQTT broker CA certificate is unreadable")
+
+        if not ca_contents:
+            logger.error(f"MQTT broker CA certificate at {ca_path} is empty; refusing K8S-SAT MQTT connection")
+            raise RuntimeError("MQTT broker CA certificate is empty")
+
+        try:
+            self.client.tls_set(
+                ca_certs=str(ca_path),
+                cert_reqs=ssl.CERT_REQUIRED,
+                tls_version=ssl.PROTOCOL_TLS_CLIENT
+            )
+        except (OSError, ssl.SSLError):
+            logger.error(f"MQTT broker CA certificate at {ca_path} is invalid; refusing K8S-SAT MQTT connection")
+            raise RuntimeError("MQTT broker CA certificate is invalid")
+
+        logger.info(f"MQTT TLS configured with server verification ({ca_path})")
     
     def _setup_sat_auth(self):
         """Configure ServiceAccountToken authentication."""
         mqtt_config = self.config['mqtt']
         token_path = Path(mqtt_config['sat_token_path'])
         
-        # Skip SAT auth if token doesn't exist (local testing)
         if not token_path.exists():
-            if mqtt_config['auth_method'] == 'K8S-SAT':
-                logger.warning(f"SAT token not found at {token_path}, skipping authentication")
-                logger.warning("For local testing, use MQTT_AUTH_METHOD=none")
-            return
-        
-        token = token_path.read_text().strip()
-        logger.info(f"✓ Read SAT token from {token_path} ({len(token)} chars)")
+            logger.error(f"SAT token not found at {token_path}; refusing K8S-SAT MQTT connection")
+            raise RuntimeError("SAT token is unavailable")
+
+        try:
+            token = token_path.read_text().strip()
+        except OSError:
+            logger.error(f"SAT token at {token_path} is unreadable; refusing K8S-SAT MQTT connection")
+            raise RuntimeError("SAT token is unreadable")
+
+        if not token:
+            logger.error(f"SAT token at {token_path} is empty; refusing K8S-SAT MQTT connection")
+            raise RuntimeError("SAT token is empty")
+
+        logger.info(f"✓ Read SAT token from {token_path}")
         
         # Set up MQTT v5 enhanced authentication
         self.connect_properties = mqtt.Properties(mqtt.PacketTypes.CONNECT)

--- a/quickstart/modules/demohistorian/config.yaml
+++ b/quickstart/modules/demohistorian/config.yaml
@@ -11,6 +11,7 @@ mqtt:
   reconnect_delay: 5
   protocol_version: 5  # MQTT v5 required for K8S-SAT
   sat_token_path: /var/run/secrets/tokens/broker-sat
+  ca_cert_path: /var/run/certs/ca.crt
   sat_audience: aio-internal
   client_id_prefix: historian
 

--- a/quickstart/modules/demohistorian/deployment.yaml
+++ b/quickstart/modules/demohistorian/deployment.yaml
@@ -104,6 +104,8 @@ spec:
             value: K8S-SAT
           - name: SAT_TOKEN_PATH
             value: /var/run/secrets/tokens/broker-sat
+          - name: MQTT_CA_CERT_PATH
+            value: /var/run/certs/ca.crt
           - name: MQTT_TOPIC_PREFIX
             value: factory
           
@@ -121,6 +123,9 @@ spec:
           # ServiceAccountToken for MQTT authentication
           - name: broker-sat
             mountPath: /var/run/secrets/tokens
+            readOnly: true
+          - name: aio-ca-trust-bundle
+            mountPath: /var/run/certs
             readOnly: true
         
         livenessProbe:
@@ -161,6 +166,11 @@ spec:
                   path: broker-sat
                   expirationSeconds: 86400  # 24 hours
                   audience: aio-internal
+
+        # AIO-managed public CA for MQTT broker server verification
+        - name: aio-ca-trust-bundle
+          configMap:
+            name: azure-iot-operations-aio-ca-trust-bundle
 ---
 apiVersion: v1
 kind: Service

--- a/quickstart/modules/demohistorian/edge_historian.md
+++ b/quickstart/modules/demohistorian/edge_historian.md
@@ -139,6 +139,14 @@ class MQTTSubscriber:
         
     def setup_authentication(self):
         """Configure ServiceAccountToken authentication for IoT Operations broker."""
+      # Validate the broker before reading or sending the SAT
+      ca_path = Path(self.config['mqtt']['ca_cert_path'])
+      self.client.tls_set(
+        ca_certs=str(ca_path),
+        cert_reqs=ssl.CERT_REQUIRED,
+        tls_version=ssl.PROTOCOL_TLS_CLIENT,
+      )
+
         # Read K8S ServiceAccountToken
         token_path = Path(self.config['mqtt']['sat_token_path'])
         token = token_path.read_text().strip()
@@ -147,9 +155,6 @@ class MQTTSubscriber:
         auth_properties = mqtt.Properties(packetType=mqtt.PacketTypes.CONNECT)
         auth_properties.AuthenticationMethod = 'K8S-SAT'
         auth_properties.AuthenticationData = token.encode('utf-8')
-        
-        # TLS required but no cert verification for in-cluster
-        self.client.tls_set(cert_reqs=ssl.CERT_NONE)
         
         return auth_properties
         
@@ -246,6 +251,7 @@ mqtt:
   reconnect_delay: 5  # seconds
   protocol_version: 5  # MQTT v5 required for K8S-SAT auth
   sat_token_path: /var/run/secrets/tokens/broker-sat
+  ca_cert_path: /var/run/certs/ca.crt
   sat_audience: aio-internal  # Must match broker configuration
   
 database:
@@ -633,6 +639,7 @@ data:
       reconnect_delay: 5
       protocol_version: 5
       sat_token_path: /var/run/secrets/tokens/broker-sat
+      ca_cert_path: /var/run/certs/ca.crt
       sat_audience: aio-internal
     
     database:

--- a/quickstart/modules/edgemqttsim/README.md
+++ b/quickstart/modules/edgemqttsim/README.md
@@ -62,6 +62,7 @@ Messages are routed to different MQTT topics based on type:
 | `MQTT_CLIENT_ID` | `factory-sim-{pid}` | MQTT client identifier |
 | `MQTT_AUTH_METHOD` | `K8S-SAT` | Authentication method |
 | `SAT_TOKEN_PATH` | `/var/run/secrets/tokens/broker-sat` | Path to SAT token |
+| `MQTT_CA_CERT_PATH` | `/var/run/certs/ca.crt` | Path to the AIO broker CA |
 | `MESSAGE_CONFIG_PATH` | `message_structure.yaml` | Path to message config |
 | `PYTHONUNBUFFERED` | `1` | Python output buffering |
 
@@ -82,27 +83,22 @@ The `message_structure.yaml` file controls all aspects of message generation:
 ### Prerequisites
 
 - Kubernetes cluster with Azure IoT Operations installed
-- Service account `mqtt-client` with appropriate permissions
+- Azure Arc connectivity to the cluster
+- An `aio_config.json` file for the target environment
 - Container registry access
 
-### Build and Push
+### Quick Deploy
 
-```bash
-# Build the container
-docker build -t <YOUR_REGISTRY>/edgemqttsim:latest .
+From the repository root:
 
-# Push to registry
-docker push <YOUR_REGISTRY>/edgemqttsim:latest
+```powershell
+.\quickstart\external_configuration\Deploy-EdgeModules.ps1 -ConfigPath "<path-to-aio_config.json>" -ModuleName edgemqttsim -Force
 ```
 
-### Deploy to Kubernetes
-
-1. Update `deployment.yaml` with your container registry
-2. Apply the deployment:
-
-```bash
-kubectl apply -f deployment.yaml
-```
+The script builds and pushes the image, connects through Azure Arc, ensures the
+`mqtt-client` service account, refreshes the AIO-managed broker CA trust bundle in
+`default`, and applies `deployment.yaml`. When the configured registry is ACR, the
+script uses an ACR cloud build and does not require local Docker.
 
 ### Register Assets in Azure IoT Operations
 

--- a/quickstart/modules/edgemqttsim/app.py
+++ b/quickstart/modules/edgemqttsim/app.py
@@ -24,6 +24,7 @@ MQTT_CLIENT_ID = os.environ.get('MQTT_CLIENT_ID', f'factory-sim-{os.getpid()}')
 # ServiceAccountToken authentication settings
 AUTH_METHOD = os.environ.get('MQTT_AUTH_METHOD', 'K8S-SAT')  # Default to SAT
 SAT_TOKEN_PATH = os.environ.get('SAT_TOKEN_PATH', '/var/run/secrets/tokens/broker-sat')
+MQTT_CA_CERT_PATH = os.environ.get('MQTT_CA_CERT_PATH', '/var/run/certs/ca.crt')
 
 # Message generator configuration
 MESSAGE_CONFIG_PATH = os.environ.get('MESSAGE_CONFIG_PATH', 'message_structure.yaml')
@@ -44,18 +45,60 @@ stats_lock = threading.Lock()
 
 def get_sat_token():
     """Read the ServiceAccountToken from the mounted volume."""
-    try:
-        token_path = Path(SAT_TOKEN_PATH)
-        if token_path.exists():
-            token = token_path.read_text().strip()
-            print(f"[OK] Read SAT token from {SAT_TOKEN_PATH} ({len(token)} chars)")
-            return token
-        else:
-            print(f"[ERROR] SAT token file not found at {SAT_TOKEN_PATH}")
-            return None
-    except Exception as e:
-        print(f"[ERROR] Error reading SAT token: {e}")
+    token_path = Path(SAT_TOKEN_PATH)
+
+    if not token_path.exists():
+        print(f"[ERROR] SAT token not found at {token_path}; refusing K8S-SAT MQTT connection")
         return None
+
+    try:
+        if not token_path.is_file():
+            raise OSError
+        token = token_path.read_text().strip()
+    except OSError:
+        print(f"[ERROR] SAT token at {token_path} is unreadable; refusing K8S-SAT MQTT connection")
+        return None
+
+    if not token:
+        print(f"[ERROR] SAT token at {token_path} is empty; refusing K8S-SAT MQTT connection")
+        return None
+
+    print(f"[OK] Read SAT token from {token_path}")
+    return token
+
+
+def configure_tls(client):
+    """Configure server-authenticated TLS for the MQTT connection."""
+    ca_path = Path(MQTT_CA_CERT_PATH)
+
+    if not ca_path.exists():
+        print(f"[ERROR] MQTT broker CA certificate not found at {ca_path}; refusing K8S-SAT MQTT connection")
+        return False
+
+    try:
+        if not ca_path.is_file():
+            raise OSError
+        ca_contents = ca_path.read_bytes()
+    except OSError:
+        print(f"[ERROR] MQTT broker CA certificate at {ca_path} is unreadable; refusing K8S-SAT MQTT connection")
+        return False
+
+    if not ca_contents:
+        print(f"[ERROR] MQTT broker CA certificate at {ca_path} is empty; refusing K8S-SAT MQTT connection")
+        return False
+
+    try:
+        client.tls_set(
+            ca_certs=str(ca_path),
+            cert_reqs=ssl.CERT_REQUIRED,
+            tls_version=ssl.PROTOCOL_TLS_CLIENT,
+            ciphers=None
+        )
+    except (OSError, ssl.SSLError):
+        print(f"[ERROR] MQTT broker CA certificate at {ca_path} is invalid; refusing K8S-SAT MQTT connection")
+        return False
+
+    return True
 
 
 def on_connect(client, userdata, flags, reason_code, properties=None):
@@ -284,35 +327,31 @@ def main():
         transport="tcp"
     )
     
-    # Configure TLS for encrypted connection
+    if AUTH_METHOD != 'K8S-SAT':
+        print(f"\n✗ Unsupported authentication method '{AUTH_METHOD}'; refusing MQTT connection")
+        return
+
+    # Configure TLS before reading the ServiceAccount token
     print("🔒 Setting up TLS connection...")
-    client.tls_set(
-        ca_certs=None,  # Don't verify server cert (self-signed in cluster)
-        cert_reqs=ssl.CERT_NONE,
-        tls_version=ssl.PROTOCOL_TLS_CLIENT,
-        ciphers=None
-    )
-    client.tls_insecure_set(True)
-    print("✓ TLS configured (encrypted connection, no server verification)")
+    if not configure_tls(client):
+        return
+    print(f"✓ TLS configured with server verification ({MQTT_CA_CERT_PATH})")
     
     # Configure authentication
     connect_properties = None
     
-    if AUTH_METHOD == 'K8S-SAT':
-        print("\n🔑 Configuring ServiceAccountToken (K8S-SAT) authentication...")
-        token = get_sat_token()
-        if not token:
-            print("✗ Cannot connect without SAT token")
-            return
-        
-        connect_properties = mqtt.Properties(mqtt.PacketTypes.CONNECT)
-        connect_properties.AuthenticationMethod = 'K8S-SAT'
-        connect_properties.AuthenticationData = token.encode('utf-8')
-        
-        print("✓ K8S-SAT authentication configured")
-        print(f"  Token length: {len(token)} characters")
-    else:
-        print(f"\n⚠ Warning: Unknown authentication method '{AUTH_METHOD}'")
+    print("\n🔑 Configuring ServiceAccountToken (K8S-SAT) authentication...")
+    token = get_sat_token()
+    if not token:
+        print("✗ Cannot connect without SAT token")
+        return
+
+    connect_properties = mqtt.Properties(mqtt.PacketTypes.CONNECT)
+    connect_properties.AuthenticationMethod = 'K8S-SAT'
+    connect_properties.AuthenticationData = token.encode('utf-8')
+
+    print("✓ K8S-SAT authentication configured")
+    print(f"  Token length: {len(token)} characters")
     
     # Set callbacks
     client.on_connect = on_connect

--- a/quickstart/modules/edgemqttsim/deployment.yaml
+++ b/quickstart/modules/edgemqttsim/deployment.yaml
@@ -40,6 +40,8 @@ spec:
           value: "K8S-SAT"  # Use Kubernetes ServiceAccountToken
         - name: SAT_TOKEN_PATH
           value: "/var/run/secrets/tokens/broker-sat"  # Token will be mounted here
+        - name: MQTT_CA_CERT_PATH
+          value: "/var/run/certs/ca.crt"
         # Message configuration path (optional, uses default if not specified)
         - name: MESSAGE_CONFIG_PATH
           value: "message_structure.yaml"
@@ -62,6 +64,9 @@ spec:
         - name: broker-sat
           mountPath: /var/run/secrets/tokens
           readOnly: true
+        - name: aio-ca-trust-bundle
+          mountPath: /var/run/certs
+          readOnly: true
       volumes:
       - name: broker-sat
         projected:
@@ -70,3 +75,6 @@ spec:
               path: broker-sat
               expirationSeconds: 86400  # 24 hours
               audience: aio-internal  # Must match broker's audience configuration
+      - name: aio-ca-trust-bundle
+        configMap:
+          name: azure-iot-operations-aio-ca-trust-bundle

--- a/quickstart/readme.md
+++ b/quickstart/readme.md
@@ -46,8 +46,9 @@ As the end-goal is an IoT solution, this repo has a preference for installing on
 
 
 # Quick Start
-The goal here is to install IoT Operations on an Ubuntu machine (like a local NUC, PC, or a VM) so that you can get working quickly on your dataflow pipelines and get data into Fabric quickly. 
-* _if you are in a purely testing or validation phase you can create a quick VM using [this process](quick_vm_build.md)_
+The goal of this quickstart is to install IoT Operations on an Ubuntu or Windows machine (like a local NUC, PC, or a VM) so that you can get working quickly on your dataflow pipelines and get data into Fabric quickly. Additionaly there are optional modules that you can use to deploy data simulators in your project.
+* _if you are in a purely testing or validation phase you can create a quick VM using [this process]
+(quick_vm_build.md)_
 * _if you are building on a Windows machine using AKS Edge Essentials, see the [Single Windows Machine (AKS-EE)](#path-b-single-windows-machine-aks-ee) section below._
 
 > **Using AKS Edge Essentials (Windows-based edge)?**  


### PR DESCRIPTION
## Security process update, with some minor updates to docs and deployment process. 

**NOTE** this only applies to the simulation modules `edgemqttsim`
and `demohistorian` within the AIO quickstart. Other components are unaffected. 

Confirmed as a valid CWE-295 certificate-validation issue in both `edgemqttsim`
and `demohistorian`. The MQTT clients previously transmitted the Kubernetes
ServiceAccount token while TLS certificate validation was disabled.

The fix is implemented. Both clients now require the AIO broker CA with
`ssl.CERT_REQUIRED`, preserve hostname validation, and refuse the K8S-SAT
connection before reading or sending the token when the CA is missing, unreadable,
empty, or invalid. The applications emit an explicit nonsecret log message for
each of these failure cases.

The Kubernetes manifests now mount the AIO trust bundle read-only at
`/var/run/certs/ca.crt`. `Deploy-EdgeModules.ps1` automatically refreshes the
namespace-local ConfigMap from the AIO-managed trust bundle before deploying
either module. The default listener continues to use AIO
cert-manager/trust-manager; custom Key Vault-backed certificates remain managed
through AIO SecretSync.

Validation completed in a development AIO environment. `edgemqttsim` and
`demohistorian` were both Running and Ready with zero restarts. Both logged TLS
server verification and successful MQTT connections. The simulator published
telemetry, and the historian subscribed and persisted 2,494 messages across 14
topics with zero session errors. Source scans found no remaining `CERT_NONE`,
`tls_insecure_set(True)`, or unverified-TLS guidance in the affected modules.